### PR TITLE
There is no param like $.restSetup.csrf, so csrf tokens never sends.

### DIFF
--- a/jquery.rest.js
+++ b/jquery.rest.js
@@ -88,7 +88,7 @@
       
       settings.data = settings.data || "";
       
-      if ($.restSetup.csrf && !$.isEmptyObject($.restSetup.csrf))
+      if ($.restSetup.csrfParam && $.restSetup.csrfToken)
       if (!/^(get)$/i.test(settings.type))
       if (!/(authenticity_token=)/i.test(settings.data)) {
           settings.data += (settings.data ? "&" : "") + $.restSetup.csrfParam + '=' + $.restSetup.csrfToken;


### PR DESCRIPTION
There is no param like $.restSetup.csrf, so csrf tokens never sends. Fix it.
