### PR TITLE
Set JSON content-type

### DIFF
--- a/jquery.rest.js
+++ b/jquery.rest.js
@@ -113,11 +113,6 @@
           settings.data += (settings.data ? "&" : "") + $.restSetup.csrfParam + '=' + $.restSetup.csrfToken;
       }
 
-      if (!/^(get|post)$/i.test(settings.type)) {
-          settings.data += (settings.data ? "&" : "") + $.restSetup.methodParam + '=' + settings.type.toLowerCase();
-          settings.type = "POST";
-      }
-
       return _ajax.call(this, settings);
     }
 

--- a/jquery.rest.js
+++ b/jquery.rest.js
@@ -55,6 +55,7 @@
         options = $.extend(options, {
           url: url,
           data: data,
+          contentType: "application/json",
           success: function (data, text, xhr) {
             if (success) success.call(options.context || options, data, get_headers(xhr), xhr);
           },


### PR DESCRIPTION
It seems that you're not setting an explicit content type when sending data. When I do a $.create it sends the POST with content-type: "text/html". Is there a good reason for that? My app consumes POST queries with content-type: "application/json", which at least is the default in JAX-RS when you're sending JSON data. Attached code fixes it for my app.

Thanks, this is a great library!
