### PR TITLE
Fix for problem between jquery.rest and rails' jquery_ujs driver

### DIFF
--- a/jquery.rest.js
+++ b/jquery.rest.js
@@ -123,7 +123,7 @@
           settings.type = "POST";
       }
 
-      settings.beforeSend = function (xhr) {
+      settings.beforeSend = function (xhr, ajaxSettings) {
         var context = settings.context || settings,
             contentType = settings.contentType,
             resourceContentType = /.*\.(json|xml)/i.exec(settings.url);
@@ -136,7 +136,7 @@
 
         if ( methodOverride ) xhr.setRequestHeader('X-HTTP-Method-Override', methodOverride);
 
-        if ( $.isFunction(userBeforeSend) ) userBeforeSend.apply(context, xhr);
+        if ( $.isFunction(userBeforeSend) ) userBeforeSend.call(context, xhr, ajaxSettings);
      }
 
       return _ajax.call(this, settings);


### PR DESCRIPTION
When resetting the beforeSend callback, the function passed in just needs to accept the settings param and pass it on to the jquery.ajax call later on.
