### PR TITLE
Internet Explorer returns the blank line between the headers and the content in getAllResponseHeaders.

### DIFF
--- a/jquery.rest.js
+++ b/jquery.rest.js
@@ -88,7 +88,9 @@
     }
 
     function get_headers(xhr) {
-      var headers = {}, stringHeaders = xhr.getAllResponseHeaders();
+      // trim the headers because IE likes to include the blank line between the headers
+      // and the content as part of the headers
+      var headers = {}, stringHeaders = trim.call(xhr.getAllResponseHeaders());
       $.each(stringHeaders.split("\n"), function (i, header) {
         if (header.length) {
           var matches = header.match(/^([\w\-]+):(.*)/);


### PR DESCRIPTION
Because of this, "matches" on this line:

``` javascript
var matches = header.match(/^([\w\-]+):(.*)/);
```

was being set to null and causing an exception on the next line. Trimming the blank line off of xhr.getAllResponseHeaders() fixes the problem.
